### PR TITLE
Handle programs lacking family rules as eligible

### DIFF
--- a/calc.html
+++ b/calc.html
@@ -986,10 +986,12 @@
             norm(installation[programKey]) === 'eligible';
 
           // 3b. Check family eligibility.
-          // It's eligible if at least one of the matching family rules says it is.
-          const isEligibleForFamily = matchingFamilyRules.some(
-            (rule) => rule[programKey] && norm(rule[programKey]) === 'eligible'
-          );
+          // If there are no specific family rules, treat the program as open to all.
+          const isEligibleForFamily =
+            matchingFamilyRules.length === 0 ||
+            matchingFamilyRules.some(
+              (rule) => rule[programKey] && norm(rule[programKey]) === 'eligible'
+            );
 
           // The final eligibility is a combination of both installation and family checks.
           return {


### PR DESCRIPTION
## Summary
- Consider programs without matching family rules as eligible so users see all applicable tiles

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688fd9d1a22c8320baed56330ca396b4