### PR TITLE
Remove About OCCP link from site header

### DIFF
--- a/index.html
+++ b/index.html
@@ -65,7 +65,6 @@
 
         <nav class="hidden md:flex items-center space-x-4">
           <a href="https://theoperationchildcareproject.org/" target="_blank" class="text-sm font-medium text-occp-blue hover:underline">occproject.org</a>
-          <a href="https://www.occproject.org/" target="_blank" class="text-sm font-medium text-gray-600 hover:underline">About OCCP</a>
         </nav>
 
         <div class="md:hidden">
@@ -78,7 +77,6 @@
       </div>
       <nav id="mobile-nav" class="md:hidden hidden flex-col space-y-2 pb-4">
         <a href="https://theoperationchildcareproject.org/" target="_blank" class="text-sm font-medium text-occp-blue hover:underline">occproject.org</a>
-        <a href="https://www.occproject.org/" target="_blank" class="text-sm font-medium text-gray-600 hover:underline">About OCCP</a>
       </nav>
     </div>
   </header>


### PR DESCRIPTION
## Summary
- remove About OCCP link from desktop navigation
- remove About OCCP link from mobile navigation

## Testing
- `npm test` (fails: Could not read package.json)


------
https://chatgpt.com/codex/tasks/task_e_68a4a75702e48320913942b6b26df560